### PR TITLE
feat(cms): visual editor drag/resize, gemini-1.5-flash, GitHub file fallback

### DIFF
--- a/cms/app/admin/visual-editor/page.tsx
+++ b/cms/app/admin/visual-editor/page.tsx
@@ -242,6 +242,10 @@ export default function VisualEditorPage() {
   const [pushingPR, setPushingPR] = useState(false)
   const [editMsg, setEditMsg] = useState('')
 
+  // Pending style change from drag/resize
+  const [pendingStyle, setPendingStyle] = useState<{ xpath: string; text: string; tagName: string; style: Record<string, string> } | null>(null)
+  const [pushingStyle, setPushingStyle] = useState(false)
+
   // AI tab state
   const [aiInput, setAiInput] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
@@ -266,6 +270,15 @@ export default function VisualEditorPage() {
         setTab('edit')
       } else if (e.data?.type === 'cms:structure') {
         setSections(e.data.sections ?? [])
+      } else if (e.data?.type === 'cms:styleChange') {
+        setPendingStyle({
+          xpath: e.data.xpath,
+          text: e.data.text ?? '',
+          tagName: e.data.tagName,
+          style: e.data.style,
+        })
+        setTab('edit')
+        setEditMsg('Style change captured — push to production when ready.')
       }
     }
     window.addEventListener('message', handleMessage)
@@ -284,22 +297,29 @@ export default function VisualEditorPage() {
     sendUpdate('text', val)
   }
 
-  async function applyToSiteCopy() {
+  async function applyToFile() {
     if (!selected || !selected.text) return
     setApplying(true)
     setEditMsg('')
     try {
-      const fileRes = await fetch('/api/website-manager/file?path=content/siteCopy.json')
-      if (!fileRes.ok) throw new Error('Could not read siteCopy.json')
+      const filePath = PAGE_FILE_MAP[activePage] ?? 'app/page.tsx'
+      const fileRes = await fetch(`/api/website-manager/file?path=${encodeURIComponent(filePath)}`)
+      if (!fileRes.ok) {
+        const errData = await fileRes.json().catch(() => ({} as Record<string, string>)) as Record<string, string>
+        throw new Error(errData.error ?? 'Could not read file')
+      }
       const { content } = await fileRes.json() as { content: string }
-      const parsed = JSON.parse(content)
-      const updated = replaceInJson(parsed, selected.text, editText)
-      await fetch('/api/website-manager/file', {
+      const oldText = selected.text
+      if (!content.includes(oldText)) throw new Error('Original text not found in source — use Push to PR instead')
+      const newContent = content.replace(oldText, editText)
+      const writeRes = await fetch('/api/website-manager/file', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: 'content/siteCopy.json', content: JSON.stringify(updated, null, 2) }),
+        body: JSON.stringify({ path: filePath, content: newContent }),
       })
-      setEditMsg('✓ Applied to siteCopy.json')
+      if (!writeRes.ok) throw new Error('Saved file (local write may not persist in production — use Push to PR)')
+      setEditMsg('✓ Saved to workspace')
+      setIframeKey(k => k + 1)
     } catch (e: unknown) {
       setEditMsg(e instanceof Error ? e.message : 'Apply failed')
     } finally {
@@ -312,20 +332,23 @@ export default function VisualEditorPage() {
     setPushingPR(true)
     setEditMsg('')
     try {
-      const fileRes = await fetch('/api/website-manager/file?path=content/siteCopy.json')
-      if (!fileRes.ok) throw new Error('Could not read siteCopy.json')
+      const filePath = PAGE_FILE_MAP[activePage] ?? 'app/page.tsx'
+      const fileRes = await fetch(`/api/website-manager/file?path=${encodeURIComponent(filePath)}`)
+      if (!fileRes.ok) {
+        const errData = await fileRes.json().catch(() => ({} as Record<string, string>)) as Record<string, string>
+        throw new Error(errData.error ?? 'Could not read file')
+      }
       const { content } = await fileRes.json() as { content: string }
-      const parsed = JSON.parse(content)
-      const updated = replaceInJson(parsed, selected.text ?? '', editText)
-      const newContent = JSON.stringify(updated, null, 2)
-
+      const oldText = selected.text ?? ''
+      if (oldText && !content.includes(oldText)) throw new Error('Original text not found in source file')
+      const newContent = oldText ? content.replace(oldText, editText) : content
       const res = await fetch('/api/github/website-manager/pr', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: `CMS edit: update "${selected.component}"`,
-          body: `Visual Editor change to \`${selected.component}\``,
-          files: [{ path: 'touchpulse/content/siteCopy.json', content: newContent }],
+          title: `CMS text edit: ${filePath}`,
+          body: `**Changed in** \`${filePath}\`\n\n> ${oldText.slice(0, 120)} → ${editText.slice(0, 120)}`,
+          files: [{ path: `touchpulse/${filePath}`, content: newContent }],
         }),
       })
       const data = await res.json() as { url?: string; error?: string }
@@ -336,6 +359,47 @@ export default function VisualEditorPage() {
       setEditMsg(e instanceof Error ? e.message : 'Failed')
     } finally {
       setPushingPR(false)
+    }
+  }
+
+  async function pushStyleToPR() {
+    if (!pendingStyle) return
+    setPushingStyle(true)
+    setEditMsg('')
+    try {
+      const filePath = PAGE_FILE_MAP[activePage] ?? 'app/page.tsx'
+      const fileRes = await fetch(`/api/website-manager/file?path=${encodeURIComponent(filePath)}`)
+      if (!fileRes.ok) throw new Error('Could not read file')
+      const { content } = await fileRes.json() as { content: string }
+      const styleStr = Object.entries(pendingStyle.style).map(([k, v]) => `${k}: '${v}'`).join(', ')
+      const prompt = `Add the following inline style to the \`${pendingStyle.tagName}\` element that contains the text "${pendingStyle.text.slice(0, 100)}": style={{ ${styleStr} }}. If the element already has a style prop, merge these values into it. Change only that one element.`
+      const aiRes = await fetch('/api/website-manager/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, filePath, content }),
+      })
+      const aiData = await aiRes.json() as { proposedContent?: string; reply?: string; error?: string }
+      if (!aiRes.ok) throw new Error(aiData.error ?? 'AI request failed')
+      if (!aiData.proposedContent) throw new Error(aiData.reply ?? 'AI could not apply the change')
+      const res = await fetch('/api/github/website-manager/pr', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: `CMS style: ${pendingStyle.tagName} in ${filePath}`,
+          body: `**Style applied:** \`{ ${styleStr} }\``,
+          files: [{ path: `touchpulse/${filePath}`, content: aiData.proposedContent }],
+        }),
+      })
+      const prData = await res.json() as { url?: string; error?: string }
+      if (!res.ok) throw new Error(prData.error ?? 'PR failed')
+      if (prData.url) window.open(prData.url, '_blank')
+      setEditMsg('✓ Style PR created')
+      setPendingStyle(null)
+      setIframeKey(k => k + 1)
+    } catch (e: unknown) {
+      setEditMsg(e instanceof Error ? e.message : 'Style push failed')
+    } finally {
+      setPushingStyle(false)
     }
   }
 
@@ -560,24 +624,57 @@ export default function VisualEditorPage() {
                   <div className="flex gap-2 pt-2 border-t" style={{ borderColor: 'var(--border)' }}>
                     <button
                       type="button"
-                      onClick={applyToSiteCopy}
+                      onClick={applyToFile}
                       disabled={applying}
                       className="flex-1 px-3 py-2 rounded-[7px] text-[12px] font-medium border disabled:opacity-50"
                       style={{ borderColor: 'var(--teal)', color: 'var(--teal)', background: 'transparent' }}
                     >
-                      {applying ? 'Saving…' : 'Apply to siteCopy.json'}
+                      {applying ? 'Saving…' : 'Save to workspace'}
                     </button>
                     <button
                       type="button"
                       onClick={pushToPR}
-                      disabled={pushingPR}
+                      disabled={pushingPR || !selected?.text}
                       className="flex-1 px-3 py-2 rounded-[7px] text-[12px] font-medium disabled:opacity-50"
                       style={{ background: 'var(--teal)', color: '#031119' }}
                     >
-                      {pushingPR ? 'Creating PR…' : 'Push to GitHub PR'}
+                      {pushingPR ? 'Creating PR…' : 'Push text to PR'}
                     </button>
                   </div>
-                  {editMsg && <p className="text-[12px]" style={{ color: editMsg.startsWith('✓') ? 'var(--teal)' : '#f87171' }}>{editMsg}</p>}
+
+                  {/* Pending style from drag/resize */}
+                  {pendingStyle && (
+                    <div className="rounded-[8px] p-3 flex flex-col gap-2" style={{ background: 'rgba(255,177,0,0.08)', border: '1px solid rgba(255,177,0,0.3)' }}>
+                      <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--gold)' }}>Pending style change</p>
+                      <p className="text-[12px] font-mono" style={{ color: 'var(--body)' }}>
+                        {Object.entries(pendingStyle.style).map(([k, v]) => `${k}: ${v}`).join('; ')}
+                      </p>
+                      <p className="text-[11px]" style={{ color: 'var(--muted)' }}>
+                        on &lt;{pendingStyle.tagName}&gt; — applies via AI + PR
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={pushStyleToPR}
+                          disabled={pushingStyle}
+                          className="flex-1 px-3 py-2 rounded-[7px] text-[12px] font-medium disabled:opacity-50"
+                          style={{ background: 'var(--gold)', color: '#031119' }}
+                        >
+                          {pushingStyle ? 'Pushing…' : 'Push style to production ↗'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setPendingStyle(null); setIframeKey(k => k + 1) }}
+                          className="px-3 py-2 rounded-[7px] text-[12px] border"
+                          style={{ borderColor: 'var(--border)', color: 'var(--muted)' }}
+                        >
+                          Discard
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {editMsg && <p className="text-[12px]" style={{ color: editMsg.startsWith('✓') ? 'var(--teal)' : editMsg.includes('captured') ? 'var(--gold)' : '#f87171' }}>{editMsg}</p>}
                 </>
               )}
             </div>

--- a/cms/app/api/website-manager/ai/route.ts
+++ b/cms/app/api/website-manager/ai/route.ts
@@ -26,7 +26,7 @@ async function callGemini(prompt: string, filePath: string, content: string): Pr
   const userMessage = `File: ${filePath}\n\nInstruction: ${prompt}\n\nCurrent file content:\n\`\`\`\n${content}\n\`\`\``
 
   const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/cms/app/api/website-manager/file/route.ts
+++ b/cms/app/api/website-manager/file/route.ts
@@ -1,21 +1,57 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readEditableTouchpulseFile, writeEditableTouchpulseFile } from '@/lib/website-manager/files'
+import { readEditableTouchpulseFile, writeEditableTouchpulseFile, isAllowedEditablePath } from '@/lib/website-manager/files'
 
 export const runtime = 'nodejs'
+
+async function readFromGitHub(relPath: string): Promise<string> {
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.GITHUB_REPO ?? 'liamgeschwindt1/website'
+  if (!token) throw new Error('Local file not found and GITHUB_TOKEN not configured')
+  const encoded = relPath.split('/').map(encodeURIComponent).join('/')
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/contents/touchpulse/${encoded}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      cache: 'no-store',
+    }
+  )
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({} as { message?: string })) as { message?: string }
+    throw new Error(err.message ?? `GitHub: file not found (${res.status})`)
+  }
+  const data = await res.json() as { content?: string }
+  if (!data.content) throw new Error('GitHub returned empty content')
+  return Buffer.from(data.content, 'base64').toString('utf8')
+}
 
 export async function GET(req: NextRequest) {
   const relPath = req.nextUrl.searchParams.get('path')
   if (!relPath) {
     return NextResponse.json({ error: 'path is required' }, { status: 400 })
   }
+  if (!isAllowedEditablePath(relPath)) {
+    return NextResponse.json({ error: 'Path is not allowed' }, { status: 400 })
+  }
 
+  // Try local filesystem first (works in dev), then fall back to GitHub API (works in production)
   try {
     const content = await readEditableTouchpulseFile(relPath)
-    return NextResponse.json({ path: relPath, content })
+    return NextResponse.json({ path: relPath, content, source: 'local' })
+  } catch {
+    // Local file not available — CMS is running in a separate container from touchpulse
+  }
+
+  try {
+    const content = await readFromGitHub(relPath)
+    return NextResponse.json({ path: relPath, content, source: 'github' })
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to read file' },
-      { status: 400 },
+      { status: 404 },
     )
   }
 }
@@ -42,3 +78,4 @@ export async function POST(req: NextRequest) {
     )
   }
 }
+

--- a/touchpulse/components/CMSOverlay.tsx
+++ b/touchpulse/components/CMSOverlay.tsx
@@ -4,10 +4,14 @@ import { useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 
 /**
- * When the site is loaded inside the CMS Visual Editor (/?cms=true),
- * this component activates hover outlines and click-to-select behaviour,
- * sending postMessage events to the parent CMS window.
- * It also listens for 'cms:update' messages and applies live text/src edits.
+ * Activated when the site is loaded inside the CMS Visual Editor (?cms=true).
+ * Features:
+ *  - Hover outlines on editable elements
+ *  - Click to select — sends cms:select to parent
+ *  - Drag-to-move selected element (position: relative offsets)
+ *  - 8 resize handles on selected element
+ *  - On drag/resize end sends cms:styleChange to parent
+ *  - Listens for cms:update (text/src/alt), cms:applyStyle
  */
 export default function CMSOverlay() {
   const params = useSearchParams()
@@ -16,16 +20,25 @@ export default function CMSOverlay() {
   useEffect(() => {
     if (!enabled) return
 
-    // Inject outline styles
-    const style = document.createElement('style')
-    style.id = 'cms-overlay-styles'
-    style.textContent = `
+    const styleEl = document.createElement('style')
+    styleEl.textContent = `
       [data-cms-hover] { outline: 2px solid rgba(1,180,175,0.55) !important; outline-offset: 2px !important; cursor: pointer !important; }
-      [data-cms-selected] { outline: 2px solid rgba(1,180,175,1) !important; outline-offset: 2px !important; cursor: pointer !important; }
+      [data-cms-selected] { outline: 2px solid rgba(1,180,175,1) !important; outline-offset: 2px !important; }
     `
-    document.head.appendChild(style)
+    document.head.appendChild(styleEl)
 
     let selectedEl: Element | null = null
+    let overlayEl: HTMLDivElement | null = null
+    let isDragging = false
+    let isResizing = false
+    let resizeDir = ''
+    let didDrag = false
+    let dragStartX = 0
+    let dragStartY = 0
+    let elStartTop = 0
+    let elStartLeft = 0
+    let elStartWidth = 0
+    let elStartHeight = 0
 
     const EDITABLE_TAGS = new Set([
       'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
@@ -68,8 +81,172 @@ export default function CMSOverlay() {
       }
     }
 
+    function removeOverlay() {
+      overlayEl?.remove()
+      overlayEl = null
+    }
+
+    function syncOverlay() {
+      if (!selectedEl || !overlayEl) return
+      const rect = selectedEl.getBoundingClientRect()
+      overlayEl.style.top = `${rect.top}px`
+      overlayEl.style.left = `${rect.left}px`
+      overlayEl.style.width = `${rect.width}px`
+      overlayEl.style.height = `${rect.height}px`
+    }
+
+    function createOverlay(el: Element) {
+      removeOverlay()
+      const htmlEl = el as HTMLElement
+      const rect = el.getBoundingClientRect()
+      elStartTop = parseFloat(htmlEl.style.top) || 0
+      elStartLeft = parseFloat(htmlEl.style.left) || 0
+      elStartWidth = rect.width
+      elStartHeight = rect.height
+
+      const ov = document.createElement('div')
+      overlayEl = ov
+      ov.setAttribute('data-cms-overlay', '1')
+      ov.style.cssText = `
+        position: fixed;
+        top: ${rect.top}px;
+        left: ${rect.left}px;
+        width: ${rect.width}px;
+        height: ${rect.height}px;
+        z-index: 99995;
+        box-sizing: border-box;
+        pointer-events: none;
+      `
+
+      // Tag label
+      const label = document.createElement('div')
+      label.style.cssText = `
+        position: absolute;
+        top: -22px; left: -1px;
+        background: #01B4AF; color: #031119;
+        font-size: 10px; font-family: monospace;
+        padding: 2px 7px; border-radius: 3px 3px 0 0;
+        user-select: none; pointer-events: none;
+        white-space: nowrap; z-index: 3;
+      `
+      label.textContent = el.tagName.toLowerCase()
+      ov.appendChild(label)
+
+      // Move area (covers the element, enables drag-to-move)
+      const moveArea = document.createElement('div')
+      moveArea.style.cssText = `
+        position: absolute; inset: 0;
+        cursor: move; pointer-events: all; z-index: 1;
+      `
+      moveArea.title = 'Drag to move'
+      ov.appendChild(moveArea)
+
+      // 8 resize handles
+      const handles = [
+        { dir: 'n',  css: 'top:-5px;left:calc(50% - 4px);cursor:n-resize;' },
+        { dir: 's',  css: 'bottom:-5px;left:calc(50% - 4px);cursor:s-resize;' },
+        { dir: 'w',  css: 'left:-5px;top:calc(50% - 4px);cursor:w-resize;' },
+        { dir: 'e',  css: 'right:-5px;top:calc(50% - 4px);cursor:e-resize;' },
+        { dir: 'nw', css: 'top:-5px;left:-5px;cursor:nw-resize;' },
+        { dir: 'ne', css: 'top:-5px;right:-5px;cursor:ne-resize;' },
+        { dir: 'sw', css: 'bottom:-5px;left:-5px;cursor:sw-resize;' },
+        { dir: 'se', css: 'bottom:-5px;right:-5px;cursor:se-resize;' },
+      ]
+      handles.forEach(({ dir, css }) => {
+        const h = document.createElement('div')
+        h.dataset.cmsHandle = dir
+        h.style.cssText = `
+          position: absolute; width: 8px; height: 8px;
+          background: #01B4AF; border: 2px solid #fff;
+          border-radius: 2px; z-index: 2; pointer-events: all;
+          ${css}
+        `
+        ov.appendChild(h)
+      })
+
+      ov.addEventListener('mousedown', (e) => {
+        const target = e.target as HTMLElement
+        const dir = target.dataset.cmsHandle
+        dragStartX = e.clientX
+        dragStartY = e.clientY
+        didDrag = false
+        const curRect = selectedEl!.getBoundingClientRect()
+        elStartWidth = curRect.width
+        elStartHeight = curRect.height
+        elStartTop = parseFloat((selectedEl as HTMLElement).style.top) || 0
+        elStartLeft = parseFloat((selectedEl as HTMLElement).style.left) || 0
+        if (dir) {
+          isResizing = true
+          resizeDir = dir
+        } else {
+          isDragging = true
+        }
+        e.preventDefault()
+        e.stopPropagation()
+      }, true)
+
+      document.body.appendChild(ov)
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      if (!isDragging && !isResizing) return
+      if (!selectedEl) return
+      const dx = e.clientX - dragStartX
+      const dy = e.clientY - dragStartY
+      if (Math.abs(dx) < 2 && Math.abs(dy) < 2) return
+      didDrag = true
+      const htmlEl = selectedEl as HTMLElement
+
+      if (isDragging) {
+        htmlEl.style.position = 'relative'
+        htmlEl.style.top = `${elStartTop + dy}px`
+        htmlEl.style.left = `${elStartLeft + dx}px`
+      } else if (isResizing) {
+        const dir = resizeDir
+        if (dir.includes('e')) htmlEl.style.width = `${Math.max(20, elStartWidth + dx)}px`
+        if (dir.includes('s')) htmlEl.style.height = `${Math.max(20, elStartHeight + dy)}px`
+        if (dir.includes('w')) {
+          htmlEl.style.width = `${Math.max(20, elStartWidth - dx)}px`
+          htmlEl.style.position = 'relative'
+          htmlEl.style.left = `${elStartLeft + dx}px`
+        }
+        if (dir.includes('n')) {
+          htmlEl.style.height = `${Math.max(20, elStartHeight - dy)}px`
+          htmlEl.style.position = 'relative'
+          htmlEl.style.top = `${elStartTop + dy}px`
+        }
+      }
+      syncOverlay()
+    }
+
+    function onMouseUp() {
+      if (!isDragging && !isResizing) return
+      isDragging = false
+      isResizing = false
+      if (!selectedEl || !didDrag) return
+
+      const htmlEl = selectedEl as HTMLElement
+      const pendingStyle: Record<string, string> = {}
+      if (htmlEl.style.position) pendingStyle.position = htmlEl.style.position
+      if (htmlEl.style.top) pendingStyle.top = htmlEl.style.top
+      if (htmlEl.style.left) pendingStyle.left = htmlEl.style.left
+      if (htmlEl.style.width) pendingStyle.width = htmlEl.style.width
+      if (htmlEl.style.height) pendingStyle.height = htmlEl.style.height
+
+      if (Object.keys(pendingStyle).length > 0) {
+        window.parent.postMessage({
+          type: 'cms:styleChange',
+          xpath: getXPath(selectedEl),
+          text: selectedEl.textContent?.trim().slice(0, 300) ?? '',
+          tagName: selectedEl.tagName.toLowerCase(),
+          style: pendingStyle,
+        }, '*')
+      }
+    }
+
     function onMouseOver(e: MouseEvent) {
       const el = e.target as Element
+      if (overlayEl?.contains(el)) return
       if (!isEditable(el)) return
       el.setAttribute('data-cms-hover', '1')
     }
@@ -80,7 +257,10 @@ export default function CMSOverlay() {
     }
 
     function onClick(e: MouseEvent) {
+      if (didDrag) { didDrag = false; return }
       const el = e.target as Element
+      if (overlayEl?.contains(el)) return
+      if ((el as HTMLElement).closest('[data-cms-overlay]')) return
       if (!isEditable(el)) return
       e.preventDefault()
       e.stopPropagation()
@@ -89,65 +269,64 @@ export default function CMSOverlay() {
       selectedEl = el
       el.setAttribute('data-cms-selected', '1')
 
+      createOverlay(el)
       window.parent.postMessage({ type: 'cms:select', ...elementData(el) }, '*')
     }
 
-    // Send section structure to parent
     function sendStructure() {
-      const sections = Array.from(
-        document.querySelectorAll('section, [data-section]')
-      ).map(el => ({
+      const sections = Array.from(document.querySelectorAll('section, [data-section]')).map(el => ({
         xpath: getXPath(el),
-        name:
-          el.getAttribute('aria-label') ??
-          el.id ??
-          el.querySelector('h1,h2,h3')?.textContent?.trim() ??
-          el.tagName.toLowerCase(),
+        name: el.getAttribute('aria-label') ?? el.id ?? el.querySelector('h1,h2,h3')?.textContent?.trim() ?? el.tagName.toLowerCase(),
       }))
       window.parent.postMessage({ type: 'cms:structure', sections }, '*')
     }
 
-    // Handle live update messages from parent CMS
     function onMessage(e: MessageEvent) {
-      if (e.data?.type !== 'cms:update') return
-      const { xpath, property, value } = e.data as { xpath: string; property: string; value: string }
-      try {
-        const result = document.evaluate(
-          xpath,
-          document,
-          null,
-          XPathResult.FIRST_ORDERED_NODE_TYPE,
-          null
-        )
-        const el = result.singleNodeValue as Element | null
-        if (!el) return
-        if (property === 'text') {
-          el.textContent = value
-        } else if (property === 'src') {
-          (el as HTMLImageElement).src = value
-        } else if (property === 'alt') {
-          (el as HTMLImageElement).alt = value
-        }
-      } catch {
-        // XPath evaluation failure — ignore
+      if (e.data?.type === 'cms:update') {
+        const { xpath, property, value } = e.data as { xpath: string; property: string; value: string }
+        try {
+          const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+          const el = result.singleNodeValue as Element | null
+          if (!el) return
+          if (property === 'text') el.textContent = value
+          else if (property === 'src') (el as HTMLImageElement).src = value
+          else if (property === 'alt') (el as HTMLImageElement).alt = value
+        } catch { /* ignore */ }
+      } else if (e.data?.type === 'cms:applyStyle') {
+        const { xpath, style } = e.data as { xpath: string; style: Record<string, string> }
+        try {
+          const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+          const el = result.singleNodeValue as HTMLElement | null
+          if (!el) return
+          Object.assign(el.style, style)
+          syncOverlay()
+        } catch { /* ignore */ }
       }
     }
 
     document.addEventListener('mouseover', onMouseOver)
     document.addEventListener('mouseout', onMouseOut)
     document.addEventListener('click', onClick, true)
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
     window.addEventListener('message', onMessage)
+    window.addEventListener('scroll', syncOverlay, { passive: true })
+    window.addEventListener('resize', syncOverlay)
 
-    // Send page structure once DOM is ready
     const rafId = requestAnimationFrame(sendStructure)
 
     return () => {
       document.removeEventListener('mouseover', onMouseOver)
       document.removeEventListener('mouseout', onMouseOut)
       document.removeEventListener('click', onClick, true)
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
       window.removeEventListener('message', onMessage)
+      window.removeEventListener('scroll', syncOverlay)
+      window.removeEventListener('resize', syncOverlay)
       cancelAnimationFrame(rafId)
-      style.remove()
+      styleEl.remove()
+      removeOverlay()
       if (selectedEl) {
         selectedEl.removeAttribute('data-cms-selected')
         selectedEl = null
@@ -157,3 +336,4 @@ export default function CMSOverlay() {
 
   return null
 }
+


### PR DESCRIPTION
- CMSOverlay: drag-to-move (position:relative) + 8 resize handles on selected element; sends cms:styleChange to parent on mouse-up
- Visual editor: handles cms:styleChange, captures pending style change, pushStyleToPR sends style via AI to generate PR (pushes to production)
- AI route: gemini-2.0-flash -> gemini-1.5-flash (2.0 no longer available)
- file GET route: GitHub API fallback when local FS not available (prod)